### PR TITLE
Refactor client.Run and add conn.go

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -159,9 +159,7 @@ func Run(ctx context.Context, conf Config) error {
 			errCh <- err
 			return
 		}
-		if err := client.Start(ctx); err != nil {
-			errCh <- err
-		}
+		client.Cancel(client.Start(ctx))
 		if err := client.Error(); err != nil {
 			errCh <- err
 		}

--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -155,31 +155,22 @@ func Run(ctx context.Context, conf Config) error {
 
 	errCh := make(chan error, 2)
 	go func() {
-		err := client.Run(ctx)
-		if err != nil {
+		if err := client.Register(ctx); err != nil {
+			errCh <- err
+			return
+		}
+		if err := client.Start(ctx); err != nil {
 			errCh <- err
 		}
 	}()
 
 	// listen for any request to create a new session
-	cancels := make(map[tunnel.Target]func())
 	select {
 	case target := <-peerAddCh:
-		ctx, cancels[target] = context.WithCancel(ctx)
-		if err := listen(ctx, client, conf.ListenAddress, target); err != nil {
-			errCh <- err
-			cancels[target]()
-		}
-	case target := <-peerDelCh:
-		cancels[target]()
-		delete(cancels, target)
-	}
-
-	select {
+		return listen(ctx, client, conf.ListenAddress, target)
 	case <-ctx.Done():
 		return ctx.Err()
 	case err := <-errCh:
 		return err
 	}
-
 }

--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -162,6 +162,9 @@ func Run(ctx context.Context, conf Config) error {
 		if err := client.Start(ctx); err != nil {
 			errCh <- err
 		}
+		if err := client.Error(); err != nil {
+			errCh <- err
+		}
 	}()
 
 	// listen for any request to create a new session

--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -159,7 +159,7 @@ func Run(ctx context.Context, conf Config) error {
 			errCh <- err
 			return
 		}
-		client.Cancel(client.Start(ctx))
+		client.Start(ctx)
 		if err := client.Error(); err != nil {
 			errCh <- err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openconfig/grpctunnel
 go 1.14
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/golang/protobuf v1.4.3
 	google.golang.org/grpc v1.34.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/tunnel/conn.go
+++ b/tunnel/conn.go
@@ -189,7 +189,7 @@ func Listen(ctx context.Context, addr string, cert string, targets map[Target]st
 	for {
 		if c, err := registerTunnelClient(ctx, addr, cert, l, targets); err == nil {
 			go func() {
-				c.Cancel(c.Start(ctx))
+				c.Start(ctx)
 				if err := c.Error(); err != nil {
 					l.chErr <- err
 				}

--- a/tunnel/conn.go
+++ b/tunnel/conn.go
@@ -1,0 +1,210 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	tpb "github.com/openconfig/grpctunnel/proto/tunnel"
+)
+
+var (
+	// RetryBaseDelay is the initial retry interval for re-connecting tunnel server/client.
+	RetryBaseDelay = time.Second
+	// RetryMaxDelay caps the retry interval for re-connecting attempts.
+	RetryMaxDelay = time.Minute
+	// RetryRandomization is the randomization factor applied to the retry
+	// interval.
+	RetryRandomization = 0.5
+)
+
+// Conn is a wraper as a net.Conn interface.
+type Conn struct {
+	io.ReadWriteCloser
+}
+
+// LocalAddr is trivial implementation, in order to match interface net.Conn.
+func (tc *Conn) LocalAddr() net.Addr { return nil }
+
+// RemoteAddr is trivial implementation, in order to match interface net.Conn.
+func (tc *Conn) RemoteAddr() net.Addr { return nil }
+
+// SetDeadline is trivial implementation, in order to match interface net.Conn.
+func (tc *Conn) SetDeadline(t time.Time) error { return nil }
+
+// SetReadDeadline is trivial implementation, in order to match interface net.Conn.
+func (tc *Conn) SetReadDeadline(t time.Time) error { return nil }
+
+// SetWriteDeadline is trivial implementation, in order to match interface net.Conn.
+func (tc *Conn) SetWriteDeadline(t time.Time) error { return nil }
+
+// ServerConn (re-)tries and returns a tunnel connection.
+func ServerConn(ctx context.Context, ts *Server, addr string, target *Target) (*Conn, error) {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 0 // Retry Subscribe indefinitely.
+	bo.InitialInterval = RetryBaseDelay
+	bo.MaxInterval = RetryMaxDelay
+	bo.RandomizationFactor = RetryRandomization
+
+	for {
+		session, err := ts.NewSession(ctx, ServerSession{Target: *target})
+		if err == nil {
+			return &Conn{session}, nil
+		}
+		duration := bo.NextBackOff()
+		time.Sleep(duration)
+		log.Printf("Failed to get tunnel connection: %v.\nRetrying in %s.", err, duration)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+	}
+
+}
+
+func registerTunnelClient(ctx context.Context, addr string, cert string, l *Listener,
+	targets map[Target]struct{}) (*Client, error) {
+	opts := []grpc.DialOption{grpc.WithDefaultCallOptions()}
+	if cert == "" {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		creds, err := credentials.NewClientTLSFromFile(cert, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to load credentials: %v", err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	}
+	var err error
+	l.cc, err = grpc.Dial(addr, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("grpc dial error: %v", err)
+	}
+
+	registerHandler := func(t Target) error {
+		if _, ok := targets[t]; !ok {
+			return fmt.Errorf("client cannot handle target ID: %s, type: %s", t.ID, t.Type)
+		}
+		log.Printf("register handler received id: %v, type: %v", t.ID, t.Type)
+		return nil
+	}
+
+	handler := func(t Target, i io.ReadWriteCloser) error {
+		log.Printf("handler called for id: %v, type: %v", t.ID, t.Type)
+		l.chIO <- i
+		return nil
+	}
+
+	client, err := NewClient(tpb.NewTunnelClient(l.cc), ClientConfig{
+		RegisterHandler: registerHandler,
+		Handler:         handler,
+	}, targets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tunnel client: %v", err)
+	}
+	if err := client.Register(ctx); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// Listener wraps a tunnel connection.
+type Listener struct {
+	conn  io.ReadWriteCloser
+	addr  tunnelAddr
+	chIO  chan io.ReadWriteCloser
+	chErr chan error
+	cc    *grpc.ClientConn
+}
+
+// Accept waits and returns a tunnel connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case err := <-l.chErr:
+		return nil, fmt.Errorf("failed to get tunnel listener: %v", err)
+	case l.conn = <-l.chIO:
+		log.Printf("tunnel listen setup")
+		conn := l.conn
+		l.conn = nil
+		return &Conn{conn}, nil
+	}
+}
+
+// Close close the embedded connection. Will need more implementation to handle multiple connections.
+func (l *Listener) Close() error {
+	var errs []string
+	if l.cc != nil {
+		if e := l.cc.Close(); e != nil {
+			errs = append(errs, fmt.Sprintf("failed to close listener.cc: %v", e))
+		}
+	}
+
+	if l.conn != nil {
+		if e := l.conn.Close(); e != nil {
+			errs = append(errs, fmt.Sprintf("failed to close listener.conn: %v", e))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf(strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+// Addr is a trivial implementation.
+func (l *Listener) Addr() net.Addr { return l.addr }
+
+type tunnelAddr struct {
+	network string
+	address string
+}
+
+func (a tunnelAddr) Network() string { return a.network }
+func (a tunnelAddr) String() string  { return a.address }
+
+// Listen create a tunnel client and returns a Listener.
+func Listen(ctx context.Context, addr string, cert string, targets map[Target]struct{}) (net.Listener, error) {
+	l := &Listener{}
+	l.addr = tunnelAddr{network: "tcp", address: addr}
+	l.chErr = make(chan error)
+	l.chIO = make(chan io.ReadWriteCloser)
+
+	// Doing a for loop so that it will retry even the tunnel server is not reachable.
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 0 // Retry Subscribe indefinitely.
+	bo.InitialInterval = RetryBaseDelay
+	bo.MaxInterval = RetryMaxDelay
+	bo.RandomizationFactor = RetryRandomization
+
+	for {
+		if c, err := registerTunnelClient(ctx, addr, cert, l, targets); err == nil {
+			go func() {
+				if err := c.Start(ctx); err != nil {
+					l.chErr <- err
+					return
+				}
+			}()
+			return l, nil
+		}
+
+		// tunnel client establishes a tunnel session if it succeeded.
+		// retry if it fails.
+		select {
+		case err := <-l.chErr:
+			log.Printf("failed to get tunnel listener: %v", err)
+		default:
+		}
+		duration := bo.NextBackOff()
+		time.Sleep(duration)
+		log.Printf("Tunnel listener will retry in %s.", duration)
+	}
+}

--- a/tunnel/conn.go
+++ b/tunnel/conn.go
@@ -193,6 +193,9 @@ func Listen(ctx context.Context, addr string, cert string, targets map[Target]st
 					l.chErr <- err
 					return
 				}
+				if c.err != nil {
+					l.chErr <- c.Error()
+				}
 			}()
 			return l, nil
 		}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -858,7 +858,8 @@ func TestClientRunBlocked(t *testing.T) {
 
 	chanErr := make(chan error, 2)
 	clientRun := func() {
-		if err := c.Start(ctx); err != nil {
+		c.Start(ctx)
+		if err := c.Error(); err != nil {
 			chanErr <- err
 		}
 	}
@@ -969,7 +970,8 @@ func TestClientRun(t *testing.T) {
 				return
 			}
 
-			err = test.c.Start(test.ctx)
+			test.c.Start(test.ctx)
+			err = test.c.Error()
 			if err == nil && test.wantErr {
 				t.Fatal("c.Run() got success, want error")
 			}
@@ -1044,7 +1046,11 @@ func TestClientStart(t *testing.T) {
 			c.addr = addr
 			retCh := make(chan ioOrErr, 1)
 			err = c.addConnection(-1, addr, retCh)
-			err = c.Start(context.Background())
+
+			ctx := context.Background()
+			ctx, c.cancelFunc = context.WithCancel(ctx)
+			c.Start(ctx)
+			err = c.Error()
 			if err == nil && test.wantErr {
 				t.Fatal("c.Start() got success, want error")
 			}


### PR DESCRIPTION
conn.go wraps tunnel client and server, and returns net.Conn. 

* It wraps tunnel server and returns a Conn, which satisfies net.Conn interface. It can be passed to grpc's dialier.
* It wraps tunnel server and returns a Listener, whose Accept will return a net.Conn. It can be used by grpc server's Serve function.