### PR TITLE
Check returned clientInfo before sending ack

### DIFF
--- a/doc/grpctunnel_design.md
+++ b/doc/grpctunnel_design.md
@@ -18,6 +18,7 @@ James Protzman, Carl Lebsack, Rob Shakir
       - [Tag Field](#tag-field)
       - [Data Field](#data-field)
       - [Close Field](#close-field)
+    - [RegisterOp Message Fields](#registerop-message-fields)
     - [Session Message Fields](#session-message-fields)
       - [Tag Field](#tag-field-1)
       - [Accept Field](#accept-field)
@@ -121,7 +122,7 @@ The figure below illustrates the communication:
 
 ```
 service Tunnel {
-  rpc Register(stream Session) returns (stream Session);
+  rpc Register(stream RegisterOp) returns (stream RegisterOp);
   rpc Tunnel(stream Data) returns (stream Data);
 }
 
@@ -188,7 +189,7 @@ The tunnel proto defines a gRPC service, `Tunnel`, which defines two rpc
 methods:
 
 1. a `register` method which allows the tunnel server to request new tunnel
-streams from the client using [session messages](#session-message-fields), and
+streams from the client using [RegisterOp messages](#registerop-message-fields), and
 2. a `tunnel` method, which is used to create new tunnel streams. These streams
 forward the data from TCP streams over a bi-directional gRPC stream of [data
 messages](#data-message-fields).
@@ -215,6 +216,10 @@ The `close` field is used by the tunnel endpoints to know when forwarding has
 finished - usually signalled by the TCP connection reaching EOF or going idle.
 Once this boolean is set, the client and server will clean up the associated
 tunnel connections.
+
+### RegisterOp Message Fields
+
+RegisterOp can be one of Target, Session or Subscription message.
 
 ### Session Message Fields
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -638,11 +638,10 @@ func (s *Server) sendUpdate(addr net.Addr, target Target, add bool) error {
 	}
 
 	clientInfo := s.clientInfo(addr)
-	rs := clientInfo.rs
-	if rs == nil {
-		return fmt.Errorf("reg stream for client %s is nil", addr)
+	if clientInfo.IsZero() {
+		return fmt.Errorf("trying to send update to a non-existing client %s", addr)
 	}
-	if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Target{Target: &tpb.Target{
+	if err := clientInfo.rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Target{Target: &tpb.Target{
 		TargetId:   target.ID,
 		TargetType: target.Type,
 		Op:         op,

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -639,6 +639,9 @@ func (s *Server) sendUpdate(addr net.Addr, target Target, add bool) error {
 
 	clientInfo := s.clientInfo(addr)
 	rs := clientInfo.rs
+	if rs == nil {
+		return fmt.Errorf("reg stream for client %s is nil", addr)
+	}
 	if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Target{Target: &tpb.Target{
 		TargetId:   target.ID,
 		TargetType: target.Type,

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -559,6 +559,9 @@ func (s *Server) subscribe(addr net.Addr, sub *tpb.Subscription) error {
 
 	// Send ack.
 	clientInfo := s.clientInfo(addr)
+	if clientInfo.IsZero() {
+		return fmt.Errorf("failed to send subscription ack for %s, its clientInfo", addr)
+	}
 	rs := clientInfo.rs
 	if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Subscription{
 		Subscription: &tpb.Subscription{


### PR DESCRIPTION
Adding a check to returned value from clientInfo, since it can access the map Server.clients which could be modified concurrently.