### PR TITLE
tunnel: fix server-side deadlock that permanently leaks target registrations

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -808,7 +808,16 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 	tag := session.GetTag()
 	if session.GetError() != "" {
 		if ch := s.connection(tag, addr); ch != nil {
-			ch <- ioOrErr{err: errors.New(session.GetError())}
+			// Deliver without blocking: the waiter in handleSession may have
+			// abandoned this channel on context cancelation. A bare send here
+			// would permanently wedge this client's Register goroutine, which
+			// in turn leaks the client's target registrations even after the
+			// underlying connection dies.
+			select {
+			case ch <- ioOrErr{err: errors.New(session.GetError())}:
+			default:
+				s.sendError(fmt.Errorf("dropping session error for tag %v: no receiver: %s", tag, session.GetError()))
+			}
 			return
 		}
 		s.sendError(fmt.Errorf("no connection associated with tag: %v", tag))
@@ -836,7 +845,9 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 		return
 	}
 
-	retCh := make(chan ioOrErr)
+	// Buffered so a response delivered after this function abandons the wait
+	// below never blocks the sender.
+	retCh := make(chan ioOrErr, 1)
 	if err := s.addConnection(tag, addr, retCh); err != nil {
 		if err := rs.Send(&tpb.RegisterOp{Registration: &tpb.RegisterOp_Session{Session: &tpb.Session{Tag: tag, Error: err.Error()}}}); err != nil {
 			s.sendError(fmt.Errorf("failed to send session error: %v", err))
@@ -857,6 +868,17 @@ func (s *Server) newClientSession(ctx context.Context, session *tpb.Session, add
 	// ctx is a child of the register stream's context
 	select {
 	case <-ctx.Done():
+		// Remove the connection so no new sender can pick it up, then drain a
+		// response that may already be buffered so its tunnel stream is
+		// released rather than leaked.
+		s.deleteConnection(tag, addr)
+		select {
+		case ioe := <-retCh:
+			if ioe.rwc != nil {
+				ioe.rwc.Close()
+			}
+		default:
+		}
 		s.sendError(ctx.Err())
 		return
 	case ioe := <-retCh:
@@ -905,7 +927,14 @@ func (s *Server) Tunnel(stream tpb.Tunnel_TunnelServer) error {
 		return errors.New("no connection associated with tag")
 	}
 	d := newIOStream(stream.Context(), stream)
-	ch <- ioOrErr{rwc: d}
+	// Deliver without blocking: the session waiter may have abandoned the
+	// channel after this handler looked it up. The channel is buffered, so a
+	// hit on the default case means another response already claimed it.
+	select {
+	case ch <- ioOrErr{rwc: d}:
+	default:
+		return fmt.Errorf("no receiver for tunnel stream with tag %d: session abandoned", tag)
+	}
 	// doneCh is the done channel created from a child context of stream.Context()
 	<-d.doneCh
 	return nil
@@ -1069,7 +1098,11 @@ func (s *Server) NewSession(ctx context.Context, ss ServerSession) (io.ReadWrite
 }
 
 func (s *Server) handleSession(ctx context.Context, tag int32, addr net.Addr, target Target, stream regStream) (_ io.ReadWriteCloser, err error) {
-	retCh := make(chan ioOrErr)
+	// Buffered so a response delivered after this function abandons the wait
+	// below (ctx canceled) never blocks the sender. The sender is the
+	// client's Register goroutine, and blocking it permanently leaks the
+	// client's target registrations even after the connection dies.
+	retCh := make(chan ioOrErr, 1)
 	if err = s.addConnection(tag, addr, retCh); err != nil {
 		return nil, fmt.Errorf("handleSession: failed to add connection: %v", err)
 	}
@@ -1089,6 +1122,18 @@ func (s *Server) handleSession(ctx context.Context, tag int32, addr net.Addr, ta
 	}
 	select {
 	case <-ctx.Done():
+		// Remove the connection so no new sender can pick it up, then drain a
+		// response that may already be buffered so its tunnel stream is
+		// released rather than leaked. The deferred deleteConnection is then
+		// a no-op.
+		s.deleteConnection(tag, addr)
+		select {
+		case ioe := <-retCh:
+			if ioe.rwc != nil {
+				ioe.rwc.Close()
+			}
+		default:
+		}
 		return nil, ctx.Err()
 	case ioe := <-retCh:
 		if ioe.err != nil {

--- a/tunnel/tunnel_deadlock_test.go
+++ b/tunnel/tunnel_deadlock_test.go
@@ -1,0 +1,102 @@
+package tunnel
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/peer"
+
+	tpb "github.com/openconfig/grpctunnel/proto/tunnel"
+)
+
+// These are regression tests for a registration-leak deadlock: a session
+// response delivered after its handleSession waiter abandoned retCh (context
+// cancelation) must never block the sender. The senders are the client's
+// Register goroutine and Tunnel stream handlers; blocking the Register
+// goroutine prevents its deferred cleanup from ever running, so the client's
+// target registrations outlive the connection and permanently lock the
+// target ID out of re-registration.
+
+const deadlockTimeout = 5 * time.Second
+
+// abandonedConnection registers a connection whose buffered response slot is
+// already taken and which has no reader, emulating a waiter that gave up
+// after a response was delivered.
+func abandonedConnection(t *testing.T, s *Server, tag int32, addr net.Addr) {
+	t.Helper()
+	retCh := make(chan ioOrErr, 1)
+	retCh <- ioOrErr{}
+	if err := s.addConnection(tag, addr, retCh); err != nil {
+		t.Fatalf("failed to add connection to test server: %v", err)
+	}
+}
+
+func TestNewClientSessionErrorDoesNotBlockWithoutReceiver(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	abandonedConnection(t, s, 1, addr)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.newClientSession(context.Background(), &tpb.Session{Tag: 1, Error: "session failed"}, addr, &regSafeStream{})
+	}()
+	select {
+	case <-done:
+	case <-time.After(deadlockTimeout):
+		t.Fatal("newClientSession blocked delivering a session error with no receiver; this wedges the client's Register goroutine")
+	}
+}
+
+func TestServerTunnelDoesNotBlockWithoutReceiver(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	abandonedConnection(t, s, 1, addr)
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Tunnel(&testDataStream{ctx: ctx, data: &tpb.Data{Tag: 1}})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Tunnel() want error for abandoned session, got nil")
+		}
+	case <-time.After(deadlockTimeout):
+		t.Fatal("Tunnel blocked delivering a stream with no receiver")
+	}
+}
+
+func TestHandleSessionAbandonReleasesConnection(t *testing.T) {
+	s, err := NewServer(ServerConfig{})
+	if err != nil {
+		t.Fatalf("NewServer(ServerConfig{}) failed: %v", err)
+	}
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:45000")
+	if err != nil {
+		t.Fatalf("failed to resolve address: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.handleSession(ctx, 7, addr, Target{ID: "target1"}, &registerTestStream{maxSends: 10}); err == nil {
+		t.Fatal("handleSession() want context error, got nil")
+	}
+	if ch := s.connection(7, addr); ch != nil {
+		t.Fatal("connection for abandoned session still registered; late responses would be orphaned")
+	}
+}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -713,7 +713,10 @@ func TestServerTunnelSuccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to resolve address: %v", err)
 		}
-		i := make(chan ioOrErr)
+		// Connection channels are buffered (cap 1) so session responses can be
+		// delivered without blocking; Tunnel drops the stream if neither the
+		// buffer nor a receiver is available.
+		i := make(chan ioOrErr, 1)
 		s.addConnection(1, addr, i)
 		ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
 		go func() {


### PR DESCRIPTION
## Problem

A session response delivered after its `handleSession` waiter has abandoned the response channel permanently blocks the sender — and the sender is the client's **Register goroutine**.

The handoff contract is asymmetric:

- `handleSession` creates an **unbuffered** `retCh`, files it in the connection map, sends the session request, and waits in `select { <-ctx.Done() / <-retCh }`. Abandoning the wait is routine, not exceptional: callers dial with timeouts, and `NewSession`'s broadcast path cancels the slower in-flight `handleSession`s as soon as the first client responds.
- `newClientSession`, running on that client's Register goroutine, delivers the response with a bare `ch <- ioOrErr{...}`.

If the response arrives after the waiter timed out (lookup happens before the waiter's `deleteConnection`), the bare send on the unbuffered channel blocks forever. From then on:

1. The Register goroutine never returns to its `Recv` loop, so even when the underlying connection later dies, `Register()` never returns and its deferred `deleteTargets` / `deleteClient` cleanup never runs.
2. The client's target registrations leak permanently — they outlive the TCP connection itself.
3. Any client that later re-registers the same target ID is rejected with `target ... already registered` forever. The only recovery is restarting the tunnel-server process.

The same bare-send pattern exists in `Server.Tunnel` (`ch <- ioOrErr{rwc: d}`), where it wedges the Tunnel stream handler goroutine and leaks the stream.

We hit this in production: a device whose gNMI dial loop generates regular session traffic wedged the Register goroutine on every tunnel-server replica over a few hours; after the device rebooted, it could not re-register anywhere ("target registration not accepted by server") until the servers were restarted. We confirmed the wedge directly — the rejections cited a holder connection that no longer existed in the server's kernel TCP table.

## Fix

Apply the contract `Client.NewSession` already uses on the client side (`make(chan ioOrErr, 1)`) to the server side, and make delivery defensive:

- **Buffer (cap 1)** the response channels in `handleSession` and in `newClientSession`'s accept path. One legitimate response exists per session tag, so one slot guarantees the first response never blocks and is never lost — including the benign race where the response arrives before the waiter reaches its `select`.
- **Non-blocking delivery** in `newClientSession` and `Server.Tunnel`: a full buffer means another response already claimed the session, so the duplicate is dropped with a logged error instead of wedging the goroutine.
- **Drain-and-close on abandonment**: when the waiter gives up via `ctx.Done()`, it removes the connection entry (no new sender can look the channel up) and drains a response that may already be buffered, closing its stream so the `Tunnel` handler is released rather than leaked.

`TestServerTunnelSuccess` is updated to the new contract (it hand-built an unbuffered connection channel and relied on the send blocking until its receiver goroutine got scheduled).

## Tests

New regression tests in `tunnel/tunnel_deadlock_test.go`:

- `TestNewClientSessionErrorDoesNotBlockWithoutReceiver` and `TestServerTunnelDoesNotBlockWithoutReceiver` simulate an abandoned session (buffered slot taken, no reader) and assert delivery returns promptly. Both **hang and fail at a 5s timeout against the current code**, and pass with this change.
- `TestHandleSessionAbandonReleasesConnection` asserts an abandoned `handleSession` leaves no connection entry behind.

`go test ./tunnel/... ./dialer/... ./bidi/...` passes.
